### PR TITLE
fix(format): mask nested templates inside ${...} interpolations

### DIFF
--- a/packages/pickier/src/format.ts
+++ b/packages/pickier/src/format.ts
@@ -815,6 +815,54 @@ export function hasIndentIssue(
   return spaces % indentSize !== 0
 }
 
+/**
+ * Skip a template literal starting at `input[start] === '\`'`, returning the
+ * index just past its closing backtick. Handles `${...}` interpolations —
+ * including nested templates and quoted strings inside them — by balancing
+ * braces, so the *correct* closing backtick is found rather than the first
+ * backtick of a nested template. Returns input.length for an unterminated
+ * (multi-line) opening.
+ */
+function skipTemplate(input: string, start: number): number {
+  let i = start + 1
+  while (i < input.length) {
+    const c = input[i]
+    if (c === '\\') {
+      i += 2
+      continue
+    }
+    if (c === '`')
+      return i + 1
+    if (c === '$' && input[i + 1] === '{') {
+      i += 2
+      let depth = 1
+      while (i < input.length && depth > 0) {
+        const d = input[i]
+        if (d === '\\') {
+          i += 2
+          continue
+        }
+        if (d === '`') {
+          i = skipTemplate(input, i)
+          continue
+        }
+        if (d === '\'' || d === '"') {
+          i = skipQuoted(input, i, d)
+          continue
+        }
+        if (d === '{')
+          depth++
+        else if (d === '}')
+          depth--
+        i++
+      }
+      continue
+    }
+    i++
+  }
+  return i
+}
+
 function maskStrings(input: string): { text: string, strings: string[] } {
   // Fast path: no quotes at all — skip character scan
   if (!input.includes('\'') && !input.includes('"') && !input.includes('`'))
@@ -831,18 +879,25 @@ function maskStrings(input: string): { text: string, strings: string[] } {
       if (i > segStart)
         parts.push(input.slice(segStart, i))
       const start = i
-      const close = ch
-      i++
-      while (i < input.length) {
-        if (input[i] === '\\') {
-          i += 2
-          continue
-        }
-        if (input[i] === close) {
-          i++
-          break
-        }
+      if (ch === '`') {
+        // Template: skip ${...} interpolations (which may contain nested
+        // templates/strings) so the real closing backtick is matched.
+        i = skipTemplate(input, i)
+      }
+      else {
+        const close = ch
         i++
+        while (i < input.length) {
+          if (input[i] === '\\') {
+            i += 2
+            continue
+          }
+          if (input[i] === close) {
+            i++
+            break
+          }
+          i++
+        }
       }
       strings.push(input.slice(start, i))
       parts.push(`@@S${strings.length - 1}@@`)

--- a/packages/pickier/test/format/template-literal-preservation.test.ts
+++ b/packages/pickier/test/format/template-literal-preservation.test.ts
@@ -104,4 +104,21 @@ describe('template literal preservation (#1361)', () => {
     expect(out).not.toContain('$ {')
     expect(out).toBe(input)
   })
+
+  // A nested template inside an interpolation, all on one line — maskStrings
+  // used to match the nested template's opening backtick as the outer close,
+  // exposing the inner ${...} to the spacing pass.
+  it('preserves a nested template inside an interpolation (single line)', () => {
+    const input = 'const k = `a${x ? `b${y}c` : z}d`\n'
+    const out = fmt(input)
+    expect(out).not.toContain('$ {')
+    expect(out).toBe(input)
+  })
+
+  it('preserves a conditional nested template interpolation (real-world key)', () => {
+    const input = 'const key = `S#${a}#${b}${r ? `#${r}` : d}`\n'
+    const out = fmt(input)
+    expect(out).not.toContain('$ {')
+    expect(out).toBe(input)
+  })
 })


### PR DESCRIPTION
Follow-up to #1361 / #1363 / #1364 — same class of corruption, different (single-line) trigger.

## Problem
`maskStrings` matches a template literal by scanning for the *next* backtick. A **nested template inside an interpolation** — e.g. `` `${cond ? `#${x}` : ''}` `` — makes it stop at the nested template's *opening* backtick, so the inner `${x}` is left unmasked and the spacing pass rewrites it to `$ {x}`, breaking interpolation. Unlike #1361 this happens even when the whole thing is on **one line**, so the earlier multi-line fix didn't cover it.

Real-world hit (turns valid code into non-compiling code):
```ts
const key = `GEO#${period}#${country}${region ? `#${region}` : ''}`
//                                              ^^^^ becomes `#$ {region}`
```

## Fix
Add `skipTemplate(input, start)` which walks a template literal balancing `${...}` (recursing into nested templates and skipping quoted strings) to find the **real** closing backtick, and use it in `maskStrings`. Single/double-quoted strings keep the existing fast scan.

## Tests
Adds two regression cases (single-line nested interpolation + a real-world conditional key) to `template-literal-preservation.test.ts`.
- Minimal repro `const k = \`a${x ? \`b${y}c\` : z}d\`` is now left unchanged
- Full suite: **2421 pass / 0 fail**; lints clean