### PR TITLE
test(format): lock in #1366 nested-interpolation regression

### DIFF
--- a/packages/pickier/test/format/template-literal-preservation.test.ts
+++ b/packages/pickier/test/format/template-literal-preservation.test.ts
@@ -121,4 +121,14 @@ describe('template literal preservation (#1361)', () => {
     expect(out).not.toContain('$ {')
     expect(out).toBe(input)
   })
+
+  // Issue #1366: the innermost ${logs} inside a nested template (itself inside a
+  // ternary interpolation) was rewritten to `$ {logs}`. Fixed by the recursive
+  // skipTemplate in #1365; this locks in the reporter's exact real-world example.
+  it('preserves a nested template inside a ternary interpolation (#1366)', () => {
+    const input = 'throw new Error(`${label} failed${logs ? `:\\n${logs}` : \'\'}`)\n'
+    const out = fmt(input)
+    expect(out).not.toContain('$ {')
+    expect(out).toBe(input)
+  })
 })


### PR DESCRIPTION
Closes #1366.

#1366 reports `${logs}` → `$ {logs}` for a nested template inside a ternary interpolation:

```ts
throw new Error(`${label} failed${logs ? `:\n${logs}` : ''}`)
//                                            ^^^ became `$ {logs}` on 0.1.33
```

**This is already fixed on `main`** by the recursive `skipTemplate` added in #1365 — which landed *after* the 0.1.33 release the reporter was running. Verified:

| Version | Output |
|---|---|
| 0.1.33 (pre-#1365) | `:\n$ {logs}` ❌ |
| current `main` | `:\n${logs}` ✅ |

Triple-nesting, deep ternary nesting, and sibling interpolations were also checked on `main` — all preserved.

This PR adds **no production code** — just the reporter's exact real-world example as a regression test so the fix can't silently regress. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)